### PR TITLE
Add script to download and import sample data for #1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Editor configuration
 launch.json
 
+# Data files
+data/

--- a/services/venue/Makefile
+++ b/services/venue/Makefile
@@ -1,6 +1,6 @@
 SERVICE = venue
 
-.PHONEY: up down start stop dbadmin
+.PHONEY: up down start stop dbadmin seed
 
 up:
 	docker-compose --project-name $(SERVICE) up --force-recreate -d
@@ -16,3 +16,6 @@ stop:
 
 dbadmin:
 	open http://localhost:8080/
+
+seed:
+	./seed.sh

--- a/services/venue/README.md
+++ b/services/venue/README.md
@@ -19,3 +19,26 @@ The service includes a Makefile to bring consistency to common development tasks
 * `make stop` - stops the service without destroying containers
 * `make start` - starts the service from a previously stopped state
 * `make dbadmin` - opens a browser window with the DB admin application
+* `make seed` -  downloads and imports sample data into the database
+
+A query to retrieve 10 cafes from the database:
+
+```sql
+SELECT name, ST_AsGeoJSON(ST_Transform(way,4326)) AS pt_lonlattext FROM  planet_osm_point WHERE amenity='cafe' LIMIT 10
+```
+
+```plain
+        name        |                     pt_lonlattext
+--------------------+--------------------------------------------------------
+ MangoBajito        | {"type":"Point","coordinates":[-0.1962976,51.5442713]}
+ The Sanctuary Café | {"type":"Point","coordinates":[-0.1918458,51.5458173]}
+ 8 oz               | {"type":"Point","coordinates":[-0.191147,51.5475357]}
+ Starbucks          | {"type":"Point","coordinates":[-0.1911542,51.5478058]}
+ Wired Co.          | {"type":"Point","coordinates":[-0.1904104,51.5465015]}
+ Zara Cafe          | {"type":"Point","coordinates":[-0.1799745,51.5418546]}
+ Chabad Lubavitch   | {"type":"Point","coordinates":[-0.1793041,51.5431459]}
+ Remon              | {"type":"Point","coordinates":[-0.179996,51.5471261]}
+ David's Deli       | {"type":"Point","coordinates":[-0.193129,51.552099]}
+ Costa              | {"type":"Point","coordinates":[-0.1911448,51.5478543]}
+(10 rows)
+```

--- a/services/venue/docker-compose.yml
+++ b/services/venue/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db:
     ports: 
       - "5432:5432"
-    image: "mdillon/postgis"
+    build: "images/db"
     restart: "always"
     environment:
       POSTGRES_PASSWORD: "devdb"

--- a/services/venue/images/db/Dockerfile
+++ b/services/venue/images/db/Dockerfile
@@ -1,0 +1,2 @@
+FROM "mdillon/postgis"
+COPY *.sql /docker-entrypoint-initdb.d/

--- a/services/venue/images/db/hstore.sql
+++ b/services/venue/images/db/hstore.sql
@@ -1,0 +1,2 @@
+/* Enable the hstore extension */
+CREATE EXTENSION hstore;

--- a/services/venue/seed.sh
+++ b/services/venue/seed.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+DATADIR=./data
+DATAFILE=sample.osm
+
+# Check we have the required utilities
+if ! [ -x "$(command -v osm2pgsql)" ]; then
+  echo 'You need to install osm2pgsql for this script to work.' >&2
+  exit 1
+fi
+
+# Create the data directory if needed
+if [ ! -d "${DATADIR}" ]; then
+    mkdir ${DATADIR}
+fi
+
+# Download sample data only if needed
+if [ -f ${DATADIR}/${DATAFILE} ]; then
+    echo "Sample data already exists, skipping download"
+else
+    curl --output "${DATADIR}/${DATAFILE}" "https://www.openstreetmap.org/api/0.6/map?bbox=-0.2031%2C51.541%2C-0.1621%2C51.5633"
+fi
+
+# Import data into PostgreSQL
+#  -l                 = store data in lat/lon rather than spherical mercartor
+#  --slim             = store temporary tables in the database rather than memory (slower)
+#x --hstore-all       = add all tags to an additional hstore (key/value) column - needs hstore
+#x --hstore-add-index = add index to hstore column - needs hstore
+osm2pgsql -l --slim --database postgres --username postgres --host localhost --password "${DATADIR}/${DATAFILE}"


### PR DESCRIPTION
This script allong with the additional `make seed` command downloads and imports a sample set of data into the postgres database. It replaces all existing data and uses the default import template for osm2pgsql.

Note: It does not use hstore and so some tag data is lost on import.